### PR TITLE
Fixed reinstall logic, made clearer prompt, and made user testing

### DIFF
--- a/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
+++ b/Source/ChocolateyGui.Common.Windows/ViewModels/Items/PackageViewModel.cs
@@ -451,6 +451,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
             }
         }
 
+        
         public async Task Reinstall()
         {
             try
@@ -458,11 +459,20 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
                 var confirmationResult = MessageDialogResult.Affirmative;
                 if (!_configService.GetEffectiveConfiguration().SkipModalDialogConfirmation.GetValueOrDefault(false))
                 {
-                    confirmationResult = await _dialogService.ShowConfirmationMessageAsync(
-                        L(nameof(Resources.Dialog_AreYouSureTitle)),
-                        L(nameof(Resources.Dialog_AreYouSureReinstallMessage), Id));
+                    var installedPackage = await _chocolateyService.GetByVersionAndIdAsync(Id, Version.ToNormalizedStringChecked(), IsPrerelease);
+                    if (installedPackage != null && installedPackage.Version > Version)
+                    {
+                        confirmationResult = await _dialogService.ShowConfirmationMessageAsync(
+                            L(nameof(Resources.Dialog_AreYouSureTitle)),
+                            L(nameof(Resources.Dialog_AreYouSureUninstallMessage), Id));
+                    }
+                    else
+                    {
+                        confirmationResult = await _dialogService.ShowConfirmationMessageAsync(
+                            L(nameof(Resources.Dialog_AreYouSureTitle)),
+                            L(nameof(Resources.Dialog_AreYouSureReinstallMessage), Id));
+                    }
                 }
-
                 if (confirmationResult == MessageDialogResult.Affirmative)
                 {
                     using (await StartProgressDialog(L(nameof(Resources.PackageViewModel_ReinstallingPackage)), L(nameof(Resources.PackageViewModel_ReinstallingPackage)), Id))
@@ -481,6 +491,7 @@ namespace ChocolateyGui.Common.Windows.ViewModels.Items
                     L(nameof(Resources.PackageViewModel_RanIntoInstallError), Id, ex.Message));
             }
         }
+                
 
         public async Task Uninstall()
         {

--- a/Source/ChocolateyGui.Common/Properties/Resources.resx
+++ b/Source/ChocolateyGui.Common/Properties/Resources.resx
@@ -1220,7 +1220,7 @@ Please contact your System Administrator to enable this operation.</value>
     <comment>{0} = The id of the package that is going to be reinstalled</comment>
   </data>
   <data name="Dialog_AreYouSureUninstallMessage" xml:space="preserve">
-    <value>This action will attempt to uninstall the '{0}' package. Are you sure you want to proceed?</value>
+    <value>You currently have a newer version of the 'PACKAGE_NAME' package installed. Are you sure you want to proceed?</value>
     <comment>{0} = The id of the package that is going to be uninstalled</comment>
   </data>
   <data name="SettingsView_SearchWatermark" xml:space="preserve">

--- a/Tests/PackageViewModelTests.cs
+++ b/Tests/PackageViewModelTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using ChocolateyGui.Common.Windows.ViewModels.Items;
+using ChocolateyGui.Common.Services;
+using ChocolateyGui.Common.Models.Messages;
+using ChocolateyGui.Common.Windows.Services;
+using AutoMapper;
+using Caliburn.Micro;
+using MahApps.Metro.Controls.Dialogs;
+using NuGet.Versioning;
+
+namespace ChocolateyGui.Tests.ViewModels
+{
+    public class PackageViewModelTests
+    {
+        private readonly Mock<IChocolateyService> _chocolateyServiceMock;
+        private readonly Mock<IEventAggregator> _eventAggregatorMock;
+        private readonly Mock<IMapper> _mapperMock;
+        private readonly Mock<IDialogService> _dialogServiceMock;
+        private readonly Mock<IProgressService> _progressServiceMock;
+        private readonly Mock<IChocolateyGuiCacheService> _chocolateyGuiCacheServiceMock;
+        private readonly Mock<IConfigService> _configServiceMock;
+        private readonly Mock<IAllowedCommandsService> _allowedCommandsServiceMock;
+        private readonly Mock<IPackageArgumentsService> _packageArgumentsServiceMock;
+        private readonly Mock<IPersistenceService> _persistenceServiceMock;
+
+        public PackageViewModelTests()
+        {
+            _chocolateyServiceMock = new Mock<IChocolateyService>();
+            _eventAggregatorMock = new Mock<IEventAggregator>();
+            _mapperMock = new Mock<IMapper>();
+            _dialogServiceMock = new Mock<IDialogService>();
+            _progressServiceMock = new Mock<IProgressService>();
+            _chocolateyGuiCacheServiceMock = new Mock<IChocolateyGuiCacheService>();
+            _configServiceMock = new Mock<IConfigService>();
+            _allowedCommandsServiceMock = new Mock<IAllowedCommandsService>();
+            _packageArgumentsServiceMock = new Mock<IPackageArgumentsService>();
+            _persistenceServiceMock = new Mock<IPersistenceService>();
+        }
+
+        [Fact]
+        public async Task Reinstall_ShouldShowConfirmationMessage_WhenNewerVersionIsInstalled()
+        {
+            // Arrange
+            var viewModel = new PackageViewModel(
+                _chocolateyServiceMock.Object,
+                _eventAggregatorMock.Object,
+                _mapperMock.Object,
+                _dialogServiceMock.Object,
+                _progressServiceMock.Object,
+                _chocolateyGuiCacheServiceMock.Object,
+                _configServiceMock.Object,
+                _allowedCommandsServiceMock.Object,
+                _packageArgumentsServiceMock.Object,
+                _persistenceServiceMock.Object)
+            {
+                Id = "testPackage",
+                Version = new NuGetVersion("1.0.0")
+            };
+
+            var installedPackage = new Package { Version = new NuGetVersion("2.0.0") };
+            _chocolateyServiceMock.Setup(s => s.GetByVersionAndIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(installedPackage);
+
+            _dialogServiceMock.Setup(d => d.ShowConfirmationMessageAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(MessageDialogResult.Affirmative);
+
+            // Act
+            await viewModel.Reinstall();
+
+            // Assert
+            _dialogServiceMock.Verify(d => d.ShowConfirmationMessageAsync(
+                It.Is<string>(s => s == "Are you sure?"),
+                It.Is<string>(s => s.Contains("You currently have a newer version of the 'testPackage' package installed"))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Reinstall_ShouldShowConfirmationMessage_WhenNoNewerVersionIsInstalled()
+        {
+            // Arrange
+            var viewModel = new PackageViewModel(
+                _chocolateyServiceMock.Object,
+                _eventAggregatorMock.Object,
+                _mapperMock.Object,
+                _dialogServiceMock.Object,
+                _progressServiceMock.Object,
+                _chocolateyGuiCacheServiceMock.Object,
+                _configServiceMock.Object,
+                _allowedCommandsServiceMock.Object,
+                _packageArgumentsServiceMock.Object,
+                _persistenceServiceMock.Object)
+            {
+                Id = "testPackage",
+                Version = new NuGetVersion("2.0.0")
+            };
+
+            var installedPackage = new Package { Version = new NuGetVersion("1.0.0") };
+            _chocolateyServiceMock.Setup(s => s.GetByVersionAndIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(installedPackage);
+
+            _dialogServiceMock.Setup(d => d.ShowConfirmationMessageAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(MessageDialogResult.Affirmative);
+
+            // Act
+            await viewModel.Reinstall();
+
+            // Assert
+            _dialogServiceMock.Verify(d => d.ShowConfirmationMessageAsync(
+                It.Is<string>(s => s == "Are you sure?"),
+                It.Is<string>(s => s.Contains("This action will attempt to reinstall the 'testPackage' package"))), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Changed the prompt to show a clearer message when a newer package has already been installed and that you would downgrade installing a worse one. I also changed the logic on the reinstall method, and made test cases to try and simulate this scenario!